### PR TITLE
with-log library prints `duration` stat at END message

### DIFF
--- a/src/with_log/core.clj
+++ b/src/with_log/core.clj
@@ -2,18 +2,19 @@
   (:require [clojure.tools.logging]))
 
 (defmacro with-log [message & body]
-  `(let [start# (. System (nanoTime))]
+  `(let [start#        (. System (nanoTime))
+         ;; borrowed from (clojure.core/time)
+         elapsed-time# #(int (/ (double (- (. System (nanoTime)) %)) 1000000.0))]
      (try
        (clojure.tools.logging/infof "BEGIN: %s" ~message)
-
        (let [ret# (do ~@body)]
-
          (clojure.tools.logging/infof
            "END (elapsed time [%d] msecs): %s"
-           (int (/ (double (- (. System (nanoTime)) start#)) 1000000.0)) ;; borrowed from (clojure.core/time)
+           (elapsed-time# start#)
            ~message)
 
          ret#)
+
        (catch Throwable tw#
          (let [ex-data# (if-let [ex-data# (ex-data tw#)]
                           (str "ex-data=" ex-data#)
@@ -21,9 +22,10 @@
            (clojure.tools.logging/warnf
              tw#
              "FAILED (elapsed time [%d] msecs): %s. %s"
-             (int (/ (double (- (. System (nanoTime)) start#)) 1000000.0)) ;; borrowed from (clojure.core/time)
+             (elapsed-time# start#)
              ~message
              ex-data#))
+
          ;; Rethrow for recovery
          (throw tw#)))))
 

--- a/src/with_log/core.clj
+++ b/src/with_log/core.clj
@@ -2,16 +2,28 @@
   (:require [clojure.tools.logging]))
 
 (defmacro with-log [message & body]
-  `(try
-     (clojure.tools.logging/infof "BEGIN: %s" ~message)
-     (let [ret# (do ~@body)]
-       (clojure.tools.logging/infof "END: %s" ~message)
-       ret#)
-     (catch Throwable tw#
-       (let [ex-data# (if-let [ex-data# (ex-data tw#)]
-                        (str "ex-data=" ex-data#)
-                        (str "no ex-data available"))]
-         (clojure.tools.logging/warnf tw# "FAILED: %s. %s" ~message ex-data#))
-       ;; Rethrow for recovery
-       (throw tw#))))
+  `(let [start# (. System (nanoTime))]
+     (try
+       (clojure.tools.logging/infof "BEGIN: %s" ~message)
+
+       (let [ret# (do ~@body)]
+
+         (clojure.tools.logging/infof
+           "END (elapsed time [%d] msecs): %s"
+           (int (/ (double (- (. System (nanoTime)) start#)) 1000000.0)) ;; borrowed from (clojure.core/time)
+           ~message)
+
+         ret#)
+       (catch Throwable tw#
+         (let [ex-data# (if-let [ex-data# (ex-data tw#)]
+                          (str "ex-data=" ex-data#)
+                          (str "no ex-data available"))]
+           (clojure.tools.logging/warnf
+             tw#
+             "FAILED (elapsed time [%d] msecs): %s. %s"
+             (int (/ (double (- (. System (nanoTime)) start#)) 1000000.0)) ;; borrowed from (clojure.core/time)
+             ~message
+             ex-data#))
+         ;; Rethrow for recovery
+         (throw tw#)))))
 

--- a/test/with_log/core_test.clj
+++ b/test/with_log/core_test.clj
@@ -10,7 +10,7 @@
         (is (= :foo (with-log msg :foo)))
 
         (is (log.test/logged? 'with-log.core-test :info (str "BEGIN: " msg)))
-        (is (log.test/logged? 'with-log.core-test :info (str "END: " msg)))))
+        (is (log.test/logged? 'with-log.core-test :info (re-pattern (str "END \\(elapsed time \\[\\d+\\] msecs\\): " msg))))))
 
     (testing "failed path"
       (let [fail-message "testing fail case"
@@ -22,5 +22,5 @@
                 (with-log msg ((fn [] (throw e))))))
 
           (is (log.test/logged? 'with-log.core-test :info (str "BEGIN: " msg)))
-          (is (log.test/logged? 'with-log.core-test :warn e (re-pattern (str "FAILED: " msg)))))))))
+          (is (log.test/logged? 'with-log.core-test :warn e (re-pattern (str "FAILED \\(elapsed time \\[\\d+\\] msecs\\): " msg)))))))))
 


### PR DESCRIPTION
Story details: https://app.clubhouse.io/motiva/story/8179